### PR TITLE
Support for abolishing curly braces

### DIFF
--- a/phpQuery/phpQuery/phpQueryObject.php
+++ b/phpQuery/phpQuery/phpQueryObject.php
@@ -1056,7 +1056,7 @@ class phpQueryObject
 				if (! $param)
 					break;
 					// nth-child(n+b) to nth-child(1n+b)
-				if ($param{0} == 'n')
+				if ($param[0] == 'n')
 					$param = '1'.$param;
 				// :nth-child(index/even/odd/equation)
 				if ($param == 'even' || $param == 'odd')
@@ -1071,17 +1071,17 @@ class phpQueryObject
 								return null;'),
 						new CallbackParam(), $param
 					);
-				else if (mb_strlen($param) > 1 && $param{1} == 'n')
+				else if (mb_strlen($param) > 1 && $param[1] == 'n')
 					// an+b
 					$mapped = $this->map(
 						create_function('$node, $param',
 							'$prevs = pq($node)->prevAll()->size();
 							$index = 1+$prevs;
 							$b = mb_strlen($param) > 3
-								? $param{3}
+								? $param[3]
 								: 0;
-							$a = $param{0};
-							if ($b && $param{2} == "-")
+							$a = $param[0];
+							if ($b && $param[2] == "-")
 								$b = -$b;
 							if ($a > 0) {
 								return ($index-$b)%$a == 0

--- a/phpQuery/phpQuery/plugins/WebBrowser.php
+++ b/phpQuery/phpQuery/plugins/WebBrowser.php
@@ -354,7 +354,7 @@ function resolve_url($base, $url) {
         // Step 3
         if (preg_match('!^[a-z]+:!i', $url)) return $url;
         $base = parse_url($base);
-        if ($url{0} == "#") {
+        if ($url[0] == "#") {
                 // Step 2 (fragment)
                 $base['fragment'] = substr($url, 1);
                 return unparse_url($base);
@@ -367,7 +367,7 @@ function resolve_url($base, $url) {
                         'scheme'=>$base['scheme'],
                         'path'=>substr($url,2),
                 ));
-        } else if ($url{0} == "/") {
+        } else if ($url[0] == "/") {
                 // Step 5
                 $base['path'] = $url;
         } else {


### PR DESCRIPTION
This is because the curly braces syntax has been deprecated in php7.4.
Thanking you in advance
https://wiki.php.net/rfc/deprecate_curly_braces_array_access